### PR TITLE
changes to healthcare bl questionnaire

### DIFF
--- a/questionnaires/health_and_care_bl/health_and_care_bl_armt.json
+++ b/questionnaires/health_and_care_bl/health_and_care_bl_armt.json
@@ -787,7 +787,7 @@
       {
         "name": "min",
         "value": "1",
-        "error": "Enter a number greater than or equal to 0",
+        "error": "Enter a number greater than 0",
         "hint": ""
       }
     ],


### PR DESCRIPTION
1. Just 1 outstanding change please, in 'Special foods or dietary supplements - number of items': error message if 0 is entered is 'Enter a number greater than or equal to 0' but it should read 'Enter a number greater than 0'. (All other error messages for this section are correct)